### PR TITLE
Fix relative paths in publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -7,7 +7,6 @@ releaseDate: '2019-05-31'
 name: PDND nteract
 url: 'https://github.com/teamdigitale/daf-nteract'
 isBasedOn: 'https://github.com/nteract/nteract'
-landingURL: 'https://github.com/teamdigitale/daf-nteract/blob/daf-develop/README.md'
 softwareVersion: v0.12.3.1
 developmentStatus: beta
 softwareType: standalone/web
@@ -76,11 +75,11 @@ description:
       - data analysis
     screenshots:
       - >-
-        https://raw.githubusercontent.com/teamdigitale/nteract/daf-develop/pdnd-tutorials/img/login.png
+        pdnd-tutorials/img/login.png
       - >-
-        https://raw.githubusercontent.com/teamdigitale/nteract/daf-develop/pdnd-tutorials/img/search.png
+        pdnd-tutorials/img/search.png
       - >-
-        https://raw.githubusercontent.com/teamdigitale/nteract/daf-develop/pdnd-tutorials/img/results.png
+        pdnd-tutorials/img/results.png
     videos:
       - 'https://www.youtube.com/watch?v=nlZnYcz66YE'
   en:
@@ -111,10 +110,10 @@ description:
       - data analysis
     screenshots:
       - >-
-        https://raw.githubusercontent.com/teamdigitale/nteract/daf-develop/pdnd-tutorials/img/login.png
+        pdnd-tutorials/img/login.png
       - >-
-        https://raw.githubusercontent.com/teamdigitale/nteract/daf-develop/pdnd-tutorials/img/search.png
+        pdnd-tutorials/img/search.png
       - >-
-        https://raw.githubusercontent.com/teamdigitale/nteract/daf-develop/pdnd-tutorials/img/results.png
+        pdnd-tutorials/img/results.png
     videos:
       - 'https://www.youtube.com/watch?v=nlZnYcz66YE'


### PR DESCRIPTION
This PR fixes the following error returned by the crawler:

```
ERRO[0043] [teamdigitale/daf-nteract] invalid publiccode.yml: description/it/screenshots: Absolute URL (https://raw.githubusercontent.com/teamdigitale/nteract/daf-develop/pdnd-tutorials/img/login.png) is outside the repository (https://raw.githubusercontent.com/teamdigitale/daf-nteract/daf-develop/)
```